### PR TITLE
Add IPFS Parser for gateway public pinata link

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -125,6 +125,8 @@ export const processIPFSURL = (image: Maybe<string>): Maybe<string> => {
     return 'https://nft-llc.mypinata.cloud/ipfs/' + image.slice(7);
   } else if (image.indexOf('https://ipfs.io/ipfs/') === 0) {
     return 'https://nft-llc.mypinata.cloud/ipfs/' + image.slice(21);
+  } else if (image.indexOf('https://gateway.pinata.cloud/ipfs/') === 0) {
+    return 'https://nft-llc.mypinata.cloud/ipfs/' + image.slice(34);
   }
   return image;
 };


### PR DESCRIPTION
<img width="1699" alt="Screen Shot 2022-06-17 at 4 38 05 PM" src="https://user-images.githubusercontent.com/7184919/174398356-597823ca-c867-449e-9b2f-cb10419a4560.png">

public gateways take 20 seconds to respond, sometimes it times out. fix parses the hash and uses our dedicated gateway for IPFS that has no rate limits