### PR TITLE
Implemented cancel preview bar and endpoint

### DIFF
--- a/components/elements/PreviewBanner.tsx
+++ b/components/elements/PreviewBanner.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+function PreviewBanner() {
+  const router = useRouter();
+  return (
+    <div
+      className='flex text-sm h-16 bg-black dark:bg-white text-white dark:text-black w-full justify-center items-center gap-16 sm:gap-4 fixed bottom-0 z-50'
+    >
+      <span>PREVIEW MODE ENABLED</span>
+      <Link
+        prefetch={false}
+        href={`/api/cancel-preview?slug=${router?.asPath}`}
+      >
+        <a
+          className="bg-white dark:bg-black text-black dark:text-white rounded decoraction p-2"
+        >
+          EXIT PREVIEW MODE
+        </a>
+      </Link>
+    </div>
+  );
+}
+
+export default PreviewBanner;

--- a/pages/api/cancel-preview.ts
+++ b/pages/api/cancel-preview.ts
@@ -1,0 +1,7 @@
+export default async function cancelPreview(req, res) {
+  const { slug } = req.query;
+
+  res.clearPreviewData();
+  res.writeHead(307, { Location: slug });
+  res.end();
+}

--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -1,4 +1,4 @@
-import { Footer } from 'components/elements/Footer';
+import PreviewBanner from 'components/elements/PreviewBanner';
 import BlogHeader from 'components/modules/BlogPage/BlogHeader';
 import BlogHeroImage from 'components/modules/BlogPage/BlogHeroImage';
 import Markdown from 'components/modules/BlogPage/Markdown';
@@ -15,7 +15,7 @@ type PostProps = {
   preview: boolean;
 };
 
-export default function Post({ post }: PostProps) {
+export default function Post({ post, preview }: PostProps) {
   const router = useRouter();
 
   if (!router.isFallback && !post) {
@@ -73,6 +73,7 @@ export default function Post({ post }: PostProps) {
           )
           : null}
       </div>
+      {preview && <PreviewBanner />}
     </>
   );
 }
@@ -82,6 +83,7 @@ export async function getServerSideProps({ params, preview = false }) {
   return {
     props: {
       post: data?.post ?? null,
+      preview
     },
   };
 }


### PR DESCRIPTION
## This PR implements a bar that shows when an internal user is in preview mode. They can click the exit preview mode button to exit preview mode and be directed back to the same page.

### Steps to test

1. Checkout branch, and run yarn dev. Navigate to `/articles/automate-with-webhooks`. The page title should look like below:

![Screen Shot 2022-06-21 at 8 57 57 AM](https://user-images.githubusercontent.com/50972198/174845275-e7b0e943-723d-4fc1-8525-2254d9a42977.png)


2. Go to the same blog post within Contentful, and on the right under preview change the platform to `Local Dev`, and click Preview. This should bring up the same blog post but in preview mode.

![Screen Shot 2022-06-21 at 8 57 00 AM](https://user-images.githubusercontent.com/50972198/174845569-43c56ceb-2ece-428c-a900-19a9f835dd3b.png)

3. You should now see `test data` in the title, as well as the preview bar at the bottom of the page.

![Screen Shot 2022-06-21 at 8 58 10 AM](https://user-images.githubusercontent.com/50972198/174845683-0c7eda3d-918e-4a70-86bc-1c56ba01b7ac.png)

![Screen Shot 2022-06-21 at 8 58 17 AM](https://user-images.githubusercontent.com/50972198/174845694-b986fda2-c072-493a-8e01-5014228382c8.png)

4. Click `Exit Preview` on the preview bar, and you should be redirected back to the same page, but not in preview mode. The title should be back to the original version `Automate with webhooks`

