### PR TITLE
fix: pass correct profile URL to profile query

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -55,7 +55,7 @@ type HomePageProps = {
 };
 
 const Index: NextPageWithLayout = ({ preview, data }: HomePageProps) => {
-  const { profileData: featuredProfile } = useProfileQuery(data?.featuredProfile?.['profileURL']);
+  const { profileData: featuredProfile } = useProfileQuery(data?.featuredProfile?.['profileURI']);
 
   if (getEnvBool(Doppler.NEXT_PUBLIC_HOMEPAGE_V2_ENABLED)) {
     return (


### PR DESCRIPTION
pass the correct value to the Profile query - the url string, not an object

this fixes the error for me locally 

```
2022-06-30T16:37:47.300Z [ERROR][graphql][general] formatError {"message":"Variable \"$url\" got invalid value { profileURI: \"km\" }; String cannot represent a non string value: { profileURI: \"km\" }","statusCode":"BAD_USER_INPUT","errorKey":"UNKNOWN"}
```