### PR TITLE
No collection banner by default

### DIFF
--- a/components/modules/Profile/CollectionGallery.tsx
+++ b/components/modules/Profile/CollectionGallery.tsx
@@ -122,20 +122,20 @@ export function CollectionGallery(props: CollectionGalleryProps) {
           />
         </div>}
       </div>
-      <div
-        className={tw('w-screen h-80',
-          'flex items-center justify-center',
-          'text-center text-2xl text-primary-txt dark:text-primary-txt-dk font-medium',
-          'mb-8',
-          'bg-auto bg-center'
-        )}
-        style={{
-          backgroundImage: `url(${
-            !isNullOrEmpty(collectionData?.openseaInfo?.collection?.banner_image_url)
-              ? collectionData?.openseaInfo?.collection?.banner_image_url
-              : 'https://cdn.nft.com/empty_profile_banner.png'})`
-        }}
-      />
+      {!isNullOrEmpty(collectionData?.openseaInfo?.collection?.banner_image_url) ?
+        <div
+          className={tw('w-screen h-80',
+            'flex items-center justify-center',
+            'text-center text-2xl text-primary-txt dark:text-primary-txt-dk font-medium',
+            'mb-8',
+            'bg-auto bg-center'
+          )}
+          style={{
+            backgroundImage: `url(${collectionData?.openseaInfo?.collection?.banner_image_url})`
+          }}
+        /> :
+        ''
+      }
       <span className='w-full text-center text-2xl text-primary-txt dark:text-primary-txt-dk mb-12 font-medium'>
         {collectionData?.collection?.name}
       </span>


### PR DESCRIPTION
We're hitting opensea rate limits so to be cognizant of this, going to not display the banner unless it is already populated by the backend cache