### PR TITLE
Collection page adjustment

### DIFF
--- a/components/modules/Collection/Collection.tsx
+++ b/components/modules/Collection/Collection.tsx
@@ -1,5 +1,4 @@
 import { AccentType, Button, ButtonType } from 'components/elements/Button';
-import Copy from 'components/elements/Copy';
 import { Footer } from 'components/elements/Footer';
 import { NFTCard } from 'components/elements/NFTCard';
 import { BannerWrapper } from 'components/modules/Profile/BannerWrapper';
@@ -50,7 +49,7 @@ export function Collection(props: CollectionProps) {
     <>
       <div className="mt-20">
         <BannerWrapper
-          imageOverride={collectionData?.ubiquityResults?.collection?.banner ? `${collectionData?.ubiquityResults?.collection?.banner} + ?apiKey=${process.env.NEXT_PUBLIC_UBIQUITY_API_KEY}` : null}/>
+          imageOverride={collectionData?.ubiquityResults?.collection?.banner ? `${collectionData?.ubiquityResults?.collection?.banner} + ?apiKey=${getEnv(Doppler.NEXT_PUBLIC_UBIQUITY_API_KEY)}` : null}/>
       </div>
       <div className="mt-7 mx-8 minmd:mx-[5%] minxl:mx-auto max-w-nftcom ">
         {collectionNfts.length > 0 ?

--- a/components/modules/Profile/CollectionGallery.tsx
+++ b/components/modules/Profile/CollectionGallery.tsx
@@ -116,7 +116,7 @@ export function CollectionGallery(props: CollectionGalleryProps) {
             'bg-auto bg-center'
           )}
           style={{
-            backgroundImage: `url(${collectionData?.ubiquityResults?.collection?.banner + `?apiKey=${process.env.NEXT_PUBLIC_UBIQUITY_API_KEY}`})`
+            backgroundImage: `url(${collectionData?.ubiquityResults?.collection?.banner ? `${collectionData?.ubiquityResults?.collection?.banner} + ?apiKey=${getEnv(Doppler.NEXT_PUBLIC_UBIQUITY_API_KEY)}` : null})`
           }}
         /> :
         ''


### PR DESCRIPTION
# Describe your changes

- Banner and link to etherscan adjustments


# Checklist before requesting a review


- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -Visit route app/collection/0xAed146B7E487B2d64b51B6D27F75c1f52247050a
       -With no ubiquityResults data provided grey defulat banner image should appear because of the NEXT_PUBLIC_ANALYTICS_ENABLED env variable value
       -Clicking on icon next to address opens etherscan tab
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -
![image](https://user-images.githubusercontent.com/41962103/184415756-6b07b1a7-9fdc-4d6f-89b4-d357fd1b1af6.png)

