### PR TITLE
Fix for missing scrollbars after modal popup - toggle sidebar close a…

### DIFF
--- a/components/elements/Sidebar.tsx
+++ b/components/elements/Sidebar.tsx
@@ -38,7 +38,7 @@ export const Sidebar = () => {
   const { data: balanceData } = useBalance({ addressOrName: currentAddress, watch: true });
 
   const { setSignOutDialogOpen } = useSignOutDialog();
-  const { sidebarOpen, setSidebarOpen, toggleSidebar } = useSidebar();
+  const { sidebarOpen, setSidebarOpen } = useSidebar();
   const randomLabel = useMemo(() => randomLabelGenerator(), []);
   const { getHiddenProfileWithExpiry, user, setCurrentProfileUrl } = useUser();
   const { addFundsDialogOpen } = useAddFundsDialog();
@@ -111,7 +111,6 @@ export const Sidebar = () => {
             onClick={() => {
               disconnect();
               setSignOutDialogOpen(true);
-              toggleSidebar();
               setCurrentProfileUrl('');
             }}>
             Sign out
@@ -168,7 +167,7 @@ export const Sidebar = () => {
         />
       );
     }
-  }, [balanceData?.formatted, balanceData?.symbol, balanceData?.value, currentAddress, disconnect, ethPriceUSD, hiddenProfile, myOwnedProfileTokens, profileValue, randomLabel, router.pathname, setCurrentProfileUrl, setSidebarOpen, setSignOutDialogOpen, toggleSidebar, user?.currentProfileUrl]);
+  }, [balanceData?.formatted, balanceData?.symbol, balanceData?.value, currentAddress, disconnect, ethPriceUSD, hiddenProfile, myOwnedProfileTokens, profileValue, randomLabel, router.pathname, setCurrentProfileUrl, setSidebarOpen, setSignOutDialogOpen, user?.currentProfileUrl]);
 
   const getSidebarPanel = useCallback(() => {
     if(isNullOrEmpty(currentAddress)) {

--- a/components/layouts/HomeLayout.tsx
+++ b/components/layouts/HomeLayout.tsx
@@ -1,4 +1,5 @@
 import { SignOutModal } from 'components/elements/SignOutModal';
+import { useSidebar } from 'hooks/state/useSidebar';
 import { useSignOutDialog } from 'hooks/state/useSignOutDialog';
 import { tw } from 'utils/tw';
 
@@ -8,6 +9,7 @@ type HomeLayoutProps = {
 
 export default function HomeLayout({ children }: HomeLayoutProps) {
   const { signOutDialogOpen, setSignOutDialogOpen } = useSignOutDialog();
+  const { toggleSidebar } = useSidebar();
   return (
     <div className={tw('flex flex-col',
       'h-screen w-full min-h-screen',
@@ -22,6 +24,7 @@ export default function HomeLayout({ children }: HomeLayoutProps) {
           visible={signOutDialogOpen}
           onClose={() => {
             setSignOutDialogOpen(false);
+            toggleSidebar();
           }}
         />
       </div>

--- a/components/layouts/PageWrapper.tsx
+++ b/components/layouts/PageWrapper.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from 'components/elements/Sidebar';
 import { SignOutModal } from 'components/elements/SignOutModal';
 import { SummaryBanner } from 'components/elements/SummaryBanner';
 import { SearchModal } from 'components/modules/Search/SearchModal';
+import { useSidebar } from 'hooks/state/useSidebar';
 import { useSignOutDialog } from 'hooks/state/useSignOutDialog';
 import ClientOnly from 'utils/ClientOnly';
 import { tw } from 'utils/tw';
@@ -33,7 +34,7 @@ export interface PageWrapperProps {
 
 export const PageWrapper = (props: PropsWithChildren<PageWrapperProps>) => {
   const { headerOptions, bgColorClasses } = props;
-
+  const { toggleSidebar } = useSidebar();
   const { signOutDialogOpen, setSignOutDialogOpen } = useSignOutDialog();
   
   const { address: currentAddress } = useAccount();
@@ -82,6 +83,7 @@ export const PageWrapper = (props: PropsWithChildren<PageWrapperProps>) => {
           visible={signOutDialogOpen}
           onClose={() => {
             setSignOutDialogOpen(false);
+            toggleSidebar();
           }}
         />
         

--- a/components/modules/HeroSidebar/HeroSidebarAccountDetails.tsx
+++ b/components/modules/HeroSidebar/HeroSidebarAccountDetails.tsx
@@ -28,7 +28,7 @@ export default function HeroSidebarAccountDetails(
   const { secondaryIcon } = useThemeColors();
   const [isCopied, setCopied] = useCopyClipboard();
   const router = useRouter();
-  const { setSidebarOpen, toggleSidebar } = useSidebar();
+  const { setSidebarOpen } = useSidebar();
   const { setSignOutDialogOpen } = useSignOutDialog();
   const { setCurrentProfileUrl } = useUser();
   const { profileTokens: ownedProfileTokens } = useMyNftProfileTokens();
@@ -121,7 +121,6 @@ export default function HeroSidebarAccountDetails(
           onClick={() => {
             disconnect();
             setSignOutDialogOpen(true);
-            toggleSidebar();
             setCurrentProfileUrl('');
           }}
         >


### PR DESCRIPTION
…fter closing modal

# Describe your changes

A fix for the missing scrollbars after the sign out dialog is active. This will toggle the sidebar to close after the modal is closed. Therefore it keeps the scrollbars 

# Associated JIRA task link

N/A

# Checklist before requesting a review


- [X] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       - testing closing modals in different pages
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         - Should not be gated as it needs to update for prod
# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

