### PR TITLE
fix: use correct variable to gate the created collection tab in edit …

### DIFF
--- a/components/modules/Profile/MintedProfileGallery.tsx
+++ b/components/modules/Profile/MintedProfileGallery.tsx
@@ -158,7 +158,7 @@ export function MintedProfileGallery(props: MintedProfileGalleryProps) {
                   onSelect: () => setLayoutEditorOpen(!layoutEditorOpen),
                   icon: <EditLayoutIcon className="w-5 h-5" alt="Hide descriptions" />,
                 },
-                getEnvBool(Doppler.NEXT_PUBLIC_ROUTER_ENABLED)
+                getEnvBool(Doppler.NEXT_PUBLIC_DEPLOYED_COLLECTIONS_ENABLED)
                   ? {
                     label: `${(draftDeployedContractsVisible) ? 'Hide' : 'Show'} Created Collections`,
                     onSelect: () => setDraftDeployedContractsVisible(!draftDeployedContractsVisible),


### PR DESCRIPTION
…mode

# Describe your changes

this was using the wrong variable >...< 

# Checklist before requesting a review


- [ ] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [x] I have added component tests for this work
- [x] I have added e2e tests for this work
- [x] I have properly gated the features with a doppler env variable:
  - [x] updated sandbox doppler config
  - [x] updated staging doppler config
  - [x] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         - `NEXT_PUBLIC_DEPLOYED_COLLECTIONS_ENABLED`

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

