### PR TITLE
fix: gate profile edit button to gk holders

### DIFF
--- a/components/modules/Profile/MintedProfileInfo.tsx
+++ b/components/modules/Profile/MintedProfileInfo.tsx
@@ -41,7 +41,7 @@ export function MintedProfileInfo(props: MintedProfileInfoProps) {
   } = useContext(ProfileContext);
 
   const getProfileButton = useCallback(() => {
-    if (!userIsAdmin) {
+    if (!userIsAdmin || !hasGks) {
       return null;
     }
     
@@ -94,7 +94,7 @@ export function MintedProfileInfo(props: MintedProfileInfoProps) {
         className="flex items-center mt-3 minlg:mt-6 "
         style={{ zIndex: 49 }}
       >
-        {hasGks && <div>
+        <div>
           <Button
             type={ButtonType.PRIMARY}
             label={'Edit Profile'}
@@ -102,7 +102,7 @@ export function MintedProfileInfo(props: MintedProfileInfoProps) {
               setEditMode(true);
             }}
           />
-        </div>}
+        </div>
         {getEnvBool(Doppler.NEXT_PUBLIC_ON_CHAIN_RESOLVER_ENABLED) && <div className='ml-4'>
           <Button
             type={ButtonType.SECONDARY}


### PR DESCRIPTION
# Describe your changes
 
this is the logic for what button we should show on the profile:

1. if the user is not the owner - show nothing
2. if the user is the owner but not "logged in" as that profile, show "switch" (no longer needs feature gating)
3. if the user is the owner and in edit mode, show "save" and "cancel"
4. if the user is the owner and doesn't own a GK, show nothing
5. if the user is the owner, and owns a GK, show "Edit" and "Settings"

- 

# Associated JIRA task link


n/a

# Checklist before requesting a review


- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       - manual testing and code review
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

