### PR TITLE
Fixed notifications that wouldn't go away

### DIFF
--- a/components/modules/Notifications/NotificationContext.tsx
+++ b/components/modules/Notifications/NotificationContext.tsx
@@ -4,6 +4,7 @@ import { useAllContracts } from 'hooks/contracts/useAllContracts';
 import { useUser } from 'hooks/state/useUser';
 import { useClaimableProfileCount } from 'hooks/useClaimableProfileCount';
 import { UserNotifications } from 'types';
+import { Doppler, getEnvBool } from 'utils/env';
 import { isNullOrEmpty } from 'utils/helpers';
 
 import React, { PropsWithChildren, useCallback, useEffect, useState } from 'react';
@@ -122,14 +123,17 @@ export function NotificationContextProvider(
     if(hasUnclaimedProfiles && !notifications.hasUnclaimedProfiles) {
       setUserNotificationActive('hasUnclaimedProfiles', true);
     }
-    if(isNullOrEmpty(pendingAssociationCount) && notifications.hasPendingAssociatedProfiles){
+    if((isNullOrEmpty(pendingAssociationCount) || pendingAssociationCount === 0) && notifications.hasPendingAssociatedProfiles){
       setUserNotificationActive('hasPendingAssociatedProfiles', false);
     }
     if(pendingAssociationCount && pendingAssociationCount > 0 && !notifications.hasPendingAssociatedProfiles ) {
       setUserNotificationActive('hasPendingAssociatedProfiles', true);
     }
-    if(profileCustomizationStatus && !profileCustomizationStatus.isProfileCustomized && !notifications.profileNeedsCustomization) {
+    if(profileCustomizationStatus && !profileCustomizationStatus.isProfileCustomized && !notifications.profileNeedsCustomization && getEnvBool(Doppler.NEXT_PUBLIC_PROFILE_FACTORY_ENABLED)) {
       setUserNotificationActive('profileNeedsCustomization', true);
+    }
+    if(profileCustomizationStatus && profileCustomizationStatus.isProfileCustomized && notifications.profileNeedsCustomization) {
+      setUserNotificationActive('profileNeedsCustomization', false);
     }
   }, [addedAssociatedNotifClicked, hasUnclaimedProfiles, pendingAssociatedProfiles, profileCustomizationStatus, removedAssociationNotifClicked, setUserNotificationActive, currentAddress, pendingAssociationCount, notifications]);
 


### PR DESCRIPTION
# Describe your changes

- Notifications wouldn't go away. Added additional checks to the if statements to make sure they only show when they are supposed to

# Associated JIRA task link

- [LINK-TO-JIRA-TASK](https://nftcom.atlassian.net/browse/NFT-702?atlOrigin=eyJpIjoiOGYzZDUzYmUwNjNjNDVkZjlmYWMzOTBlYzNmMTVjYmMiLCJwIjoiaiJ9)

# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       - testing on multiple addresses and profiles, to make sure they notifications go away and update per address
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [x] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         - NEXT_PUBLIC_PROFILE_FACTORY_ENABLED
         one notification should have been gated by the above. it was not, so hence why the notif count showed 1 but no actual notif was showing

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

