### PR TITLE
feat: use Activities endpoint to show external listings on NFT card

### DIFF
--- a/components/elements/NFTCard.tsx
+++ b/components/elements/NFTCard.tsx
@@ -1,17 +1,24 @@
+import { SupportedExternalExchange } from 'graphql/generated/types';
 import { useExternalListingsQuery } from 'graphql/hooks/useExternalListingsQuery';
-import { Doppler, getEnv } from 'utils/env';
+import { useListingActivitiesQuery } from 'graphql/hooks/useListingActivitiesQuery';
+import { useDefaultChainId } from 'hooks/useDefaultChainId';
+import { ExternalProtocol } from 'types';
+import { Doppler, getEnvBool } from 'utils/env';
 import { getGenesisKeyThumbnail, isNullOrEmpty, processIPFSURL, sameAddress } from 'utils/helpers';
 import { getAddress } from 'utils/httpHooks';
+import { getLooksrareAssetPageUrl } from 'utils/looksrareHelpers';
+import { getOpenseaAssetPageUrl } from 'utils/seaportHelpers';
 import { tw } from 'utils/tw';
 
 import { RoundedCornerMedia, RoundedCornerVariant } from './RoundedCornerMedia';
 
+import { BigNumber } from 'ethers';
 import LooksrareIcon from 'public/looksrare-icon.svg';
 import OpenseaIcon from 'public/opensea-icon.svg';
-import { MouseEvent, useCallback, useState } from 'react';
+import { MouseEvent, useCallback, useMemo, useState } from 'react';
 import { CheckSquare, Eye, EyeOff, Square } from 'react-feather';
 import { useThemeColors } from 'styles/theme/useThemeColors';
-import { useAccount, useNetwork } from 'wagmi';
+import { useAccount } from 'wagmi';
 export interface NFTCardTrait {
   key: string,
   value: string,
@@ -51,15 +58,24 @@ export function NFTCard(props: NFTCardProps) {
   const { tileBackground, secondaryText, pink, link, secondaryIcon } = useThemeColors();
 
   const { address: currentAddress } = useAccount();
-  const { chain } = useNetwork();
+  const defaultChainId = useDefaultChainId();
   const [selected, setSelected] = useState(false);
 
-  const processedImageURLs = sameAddress(props.contractAddress, getAddress('genesisKey', String(chain?.id || getEnv(Doppler.NEXT_PUBLIC_CHAIN_ID)))) && !isNullOrEmpty(props.tokenId) ?
+  const processedImageURLs = sameAddress(props.contractAddress, getAddress('genesisKey', defaultChainId)) && !isNullOrEmpty(props.tokenId) ?
     [getGenesisKeyThumbnail(props.tokenId)]
     : props.images?.map(processIPFSURL);
 
-  // todo: replace this with TxActivity query
-  const { data: listings } = useExternalListingsQuery(props?.contractAddress, props?.tokenId, String(chain?.id || getEnv(Doppler.NEXT_PUBLIC_CHAIN_ID)));
+  const { data: listings } = useListingActivitiesQuery(
+    props?.contractAddress,
+    props?.tokenId,
+    defaultChainId
+  );
+  
+  const { data: legacyListings } = useExternalListingsQuery(
+    props?.contractAddress,
+    props?.tokenId,
+    defaultChainId
+  );
 
   const makeTrait = useCallback((pair: NFTCardTrait, key: any) => {
     return <div key={key} className="flex mt-2">
@@ -74,6 +90,30 @@ export function NFTCard(props: NFTCardProps) {
       </span>
     </div>;
   }, [pink, secondaryText]);
+
+  const showListingIcons: boolean = useMemo(() => {
+    if (getEnvBool(Doppler.NEXT_PUBLIC_ROUTER_ENABLED)) {
+      return !isNullOrEmpty(listings);
+    } else {
+      return !isNullOrEmpty(legacyListings?.filter((l) => !isNullOrEmpty(l.url)));
+    }
+  }, [legacyListings, listings]);
+
+  const showOpenseaListingIcon: boolean = useMemo(() => {
+    if (getEnvBool(Doppler.NEXT_PUBLIC_ROUTER_ENABLED)) {
+      return listings?.find(activity => activity.order?.protocol === ExternalProtocol.Seaport) != null;
+    } else {
+      return legacyListings?.find(listing => listing.price != null && listing.exchange === SupportedExternalExchange.Opensea) != null;
+    }
+  }, [listings, legacyListings]);
+
+  const showLooksrareListingIcon: boolean = useMemo(() => {
+    if (getEnvBool(Doppler.NEXT_PUBLIC_ROUTER_ENABLED)) {
+      return listings?.find(activity => activity.order?.protocol === ExternalProtocol.LooksRare) != null;
+    } else {
+      return legacyListings?.find(listing => listing.price != null && listing.exchange === SupportedExternalExchange.Looksrare) != null;
+    }
+  }, [legacyListings, listings]);
 
   return (
     <div
@@ -140,36 +180,38 @@ export function NFTCard(props: NFTCardProps) {
             {props.visible ? <Eye id="eye" color={pink} /> : <EyeOff id="eyeOff" color={pink} /> }
           </div>
       }
-      {(listings?.find(listing => listing.price != null) != null) && (
+      {showListingIcons && (
         <div className='absolute left-3 top-4 z-50'>
-          {listings[0].price &&
+          {showOpenseaListingIcon &&
               <OpenseaIcon
-                onClick={() => {
+                onClick={(e: MouseEvent<any>) => {
                   window.open(
-                    listings[0].url,
+                    getOpenseaAssetPageUrl(props.contractAddress, BigNumber.from(props.tokenId).toString()),
                     '_blank'
                   );
+                  e.stopPropagation();
                 }}
                 className='h-9 w-9 relative shrink-0 hover:opacity-70 '
                 alt="Opensea logo redirect"
                 layout="fill"
               />
           }
-          {listings[1].price &&
+          {showLooksrareListingIcon &&
               <LooksrareIcon
-                onClick={() => {
+                onClick={(e: MouseEvent<any>) => {
                   window.open(
-                    listings[1].url,
+                    getLooksrareAssetPageUrl(props.contractAddress, BigNumber.from(props.tokenId).toString()),
                     '_blank'
                   );
+                  e.stopPropagation();
                 }}
                 className='h-9 w-9 relative shrink-0 hover:opacity-70'
                 alt="Looksrare logo redirect"
                 layout="fill"
               />
           }
-        </div>)
-      }
+        </div>
+      )}
       {
         props.images.length <= 1 && props.imageLayout !== 'row' ?
           <div

--- a/components/modules/NFTDetail/NFTDetailPage.tsx
+++ b/components/modules/NFTDetail/NFTDetailPage.tsx
@@ -42,7 +42,7 @@ export function NFTDetailPage(props: NFTDetailPageProps) {
     return await getContractMetadata(nft?.contract, defaultChainId);
   });
   
-  const { data: legacyListings, mutate: mutateListings } = useExternalListingsQuery(
+  const { data: legacyListings, mutate: mutateLegacyListings } = useExternalListingsQuery(
     nft?.contract,
     nft?.tokenId,
     defaultChainId
@@ -91,7 +91,7 @@ export function NFTDetailPage(props: NFTDetailPageProps) {
         <div className='flex minxl:w-1/2 w-full'>
           <NFTDetail nft={nft} onRefreshSuccess={() => {
             mutateNft();
-            mutateListings();
+            mutateLegacyListings();
           }} key={nft?.id} />
         </div>
         {(showListings || nft?.wallet === currentAddress) ?

--- a/utils/looksrareHelpers.ts
+++ b/utils/looksrareHelpers.ts
@@ -138,3 +138,7 @@ export const getLooksrareHex = (
     throw `error in getLooksrareHex: ${err}`;
   }
 };
+
+export function getLooksrareAssetPageUrl(contractAddress: string, tokenId: string) {
+  return `https://looksrare.org/collections/${contractAddress}/${tokenId}`;
+}

--- a/utils/seaportHelpers.ts
+++ b/utils/seaportHelpers.ts
@@ -275,3 +275,7 @@ export const getSeaportHex = (
     throw `error in getSeaportHex: ${err}`;
   }
 };
+
+export function getOpenseaAssetPageUrl(contractAddress: string, tokenId: string) {
+  return `https://opensea.io/assets/ethereum/${contractAddress}/${tokenId}`;
+}


### PR DESCRIPTION
# Describe your changes
when we launch the transaction router, we'll want the external listings to be consistent everywhere in our app. since we'll be relying on a new data source for these listing on the NFT Detail page, we should also switch on the NFT card.

# Associated JIRA task link

n/a

# Checklist before requesting a review


- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       - manual testing, code review
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [x] I have properly gated the features with a doppler env variable:
  - [x] updated sandbox doppler config
  - [x] updated staging doppler config
  - [x] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         - `NEXT_PUBLIC_ROUTER_ENABLED`

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

