### PR TITLE
added width query param

### DIFF
--- a/components/elements/GalleryCard.tsx
+++ b/components/elements/GalleryCard.tsx
@@ -39,7 +39,7 @@ function GalleryCard(props: GalleryCardProps) {
       /> */}
       <img
         alt=""
-        src={props?.imageURL}
+        src={props?.imageURL + '?width=600'}
         className={tw(
           'h-full w-full aspect-square rounded-xl absolute z-20',
         )}

--- a/components/elements/RoundedCornerMedia.tsx
+++ b/components/elements/RoundedCornerMedia.tsx
@@ -66,8 +66,8 @@ export const RoundedCornerMedia = React.memo(function RoundedCornerMedia(props: 
         autoPlay
         muted
         loop
-        key={props.src}
-        src={props.src}
+        key={props.src + '?width=600'}
+        src={props.src + '?width=600'}
         poster={props.src}
         className={tw(
           'object-cover absolute w-full h-full justify-center',


### PR DESCRIPTION
# Describe your changes

- Added width query param to rounded corner media 
- makes changes for homepage, gallery, nft profile, and collection pages

# Associated JIRA task link

- [LINK-TO-JIRA-TASK](https://nftcom.atlassian.net/browse/NFT-649?atlOrigin=eyJpIjoiZTE3Y2Q2MDAxZjlmNDEyNGFiYmE0Njc4ODIzN2I0OGEiLCJwIjoiaiJ9)

# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       - checked all the requested images to make sure the param was there
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

