### PR TITLE
fix: image proxy works with videos now

### DIFF
--- a/components/elements/RoundedCornerMedia.tsx
+++ b/components/elements/RoundedCornerMedia.tsx
@@ -82,7 +82,7 @@ export const RoundedCornerMedia = React.memo(function RoundedCornerMedia(props: 
     )}
     onClick={props?.onClick}
     >
-      {imageFileTypes.indexOf(ext) < 0 ?
+      {imageUrl?.indexOf('data') >= 0 ?
         <video
           autoPlay
           muted
@@ -102,7 +102,7 @@ export const RoundedCornerMedia = React.memo(function RoundedCornerMedia(props: 
           key={props.src}
           quality='50'
           layout='fill'
-          src={(imageUrl.indexOf('.svg') >= 0 && imageUrl.indexOf('nft.com') >= 0) ? imageUrl : `${getImageFetcherBaseURL()}api/imageFetcher?url=${encodeURIComponent(imageUrl)}&height=600&width=600`}
+          src={(imageUrl?.indexOf('.svg') >= 0 && imageUrl?.indexOf('nft.com') >= 0) ? imageUrl : `${getImageFetcherBaseURL()}api/imageFetcher?url=${encodeURIComponent(imageUrl)}&height=600&width=600`}
           onError={() => {
             setImageSrc(!isNullOrEmpty(props?.fallbackImage) ? processIPFSURL(props?.fallbackImage) : props?.src.includes('?width=600') ? props?.src.split('?')[0] : props.src);
           }}


### PR DESCRIPTION
# Describe your changes
Image Proxy Pro trial gives us the ability to convert videos into images (previews) to enable faster site performance

- 

# Associated JIRA task link


- LINK-TO-JIRA-TASK


# Checklist before requesting a review


- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       - I visited the localhost site and loaded images using the prod image proxy and everything loaded as expected
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work:  https://nftcom.atlassian.net/browse/NFT-822

