### PR TITLE
fix for image import issue

### DIFF
--- a/additional.d.ts
+++ b/additional.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="next/image-types/global" />

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     "**/*.js",
     "**/*.ts",
     "**/*.tsx",
-    "types/**/*.d.ts"
+    "types/**/*.d.ts",
+    "additional.d.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
# Describe your changes

- yarn build was removing `<reference types="next/image-types/global" /> ` from `next-env.d.ts`. So I added it in `additional.d.ts` and imported it per [https://nextjs.org/docs/basic-features/typescript](https://nextjs.org/docs/basic-features/typescript)

- it was causing build issues because of this

`Instead of editing next-env.d.ts, you can include additional types by adding a new file e.g. additional.d.ts and then referencing it in the [include](https://www.typescriptlang.org/tsconfig#include) array in your tsconfig.json.`

# Associated JIRA task link


- LINK-TO-JIRA-TASK


# Checklist before requesting a review


- [ ] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

