### PR TITLE
Fix activity load and memo field

### DIFF
--- a/components/modules/Analytics/CollectionActivity.tsx
+++ b/components/modules/Analytics/CollectionActivity.tsx
@@ -61,30 +61,30 @@ export const CollectionActivity = ({ contract }: CollectionActivityProps) => {
 
   return (
     <div className="overflow-x-auto my-8 font-grotesk rounded-md p-4">
-      {isNullOrEmpty(collectionData) && <p className='text-[#6F6F6F] flex items-center justify-center border h-[200px] rounded-[10px]'>No activity available</p>}
-      {!isNullOrEmpty(collectionData) &&
-      <table className="border-collapse table-auto w-full">
-        <thead className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>
-          <tr className='p-4 pt-0 pb-3 text-left ...'>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>Type</th>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4 whitespace-nowrap'>Token ID</th>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>From</th>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>To</th>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>Marketplace</th>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>Price</th>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4 whitespace-nowrap'>USD Value</th>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4 whitespace-nowrap'>Timestamp</th>
-            <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4 whitespace-nowrap'>Transaction Hash</th>
-          </tr>
-        </thead>
-        <tbody className='p-4'>
-          {collectionData?.map((tx , index) => (
-            <DetailPageTableRow key={tx?.id} tx={tx} index={index} />
-          ))}
-        </tbody>
-      </table>
+      {isNullOrEmpty(collectionData) ?
+        <p className='text-[#6F6F6F] flex items-center justify-center border h-[200px] rounded-[10px]'>No activity available</p> :
+        <table className="border-collapse table-auto w-full">
+          <thead className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>
+            <tr className='p-4 pt-0 pb-3 text-left ...'>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>Type</th>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4 whitespace-nowrap'>Token ID</th>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>From</th>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>To</th>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>Marketplace</th>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4'>Price</th>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4 whitespace-nowrap'>USD Value</th>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4 whitespace-nowrap'>Timestamp</th>
+              <th className='text-[#6F6F6F] text-sm font-medium leading-6 p-4 whitespace-nowrap'>Transaction Hash</th>
+            </tr>
+          </thead>
+          <tbody className='p-4'>
+            {collectionData?.map((tx , index) => (
+              <DetailPageTableRow key={tx?.id} tx={tx} index={index} />
+            ))}
+          </tbody>
+        </table>
       }
-      {cachedTotalCount > collectionData?.length &&
+      {cachedTotalCount > collectionData?.length && !isNullOrEmpty(collectionData) &&
         <div className='w-full flex justify-center items-center'>
           <button onClick={() => loadMoreActivities()} className="bg-[#F9D963] font-bold tracking-normal hover:bg-[#fcd034] text-base text-black py-2 px-4 rounded-full focus:outline-none focus:shadow-outline w-full minlg:w-[250px] mt-6" type="button">
                 Load More

--- a/components/modules/Analytics/NFTActivity.tsx
+++ b/components/modules/Analytics/NFTActivity.tsx
@@ -2,7 +2,7 @@ import { Nft } from 'graphql/generated/types';
 import { useGetTxByNFTQuery } from 'graphql/hooks/useGetTxByNFTQuery';
 import { useDefaultChainId } from 'hooks/useDefaultChainId';
 import { usePaginator } from 'hooks/usePaginator';
-import { filterNulls } from 'utils/helpers';
+import { filterNulls, isNullOrEmpty } from 'utils/helpers';
 
 import DetailPageTableRow from './DetailPageTableRow';
 
@@ -63,11 +63,9 @@ export const NFTActivity = ({ data }: TxHistoryProps) => {
     }
   }, [defaultChainId, nftData, nftTransactionHistory]);
 
-  console.log('nftData: ', nftData);
-
   return (
     <div className="font-noi-grotesk p-4 max-h-80 md:mb-0 overflow-x-auto sales-scrollbar whitespace-nowrap">
-      {!nftData?.length ?
+      {isNullOrEmpty(nftData) ?
         <span className='bg-white flex justify-center px-auto mx-auto w-full whitespace-nowrap font-normal text-base leading-6 text-[#1F2127] text-center items-center min-h-[280px]'>
           No Activity for this NFT yet
         </span>
@@ -92,7 +90,7 @@ export const NFTActivity = ({ data }: TxHistoryProps) => {
           </tbody>
         </table>
       }
-      {cachedTotalCount > nftData?.length && nftData?.length != 0 &&
+      {cachedTotalCount > nftData?.length && !isNullOrEmpty(nftData) &&
         <div className='w-full flex justify-center items-center'>
           <button onClick={() => loadMoreActivities()} className="bg-[#F9D963] font-bold tracking-normal hover:bg-[#fcd034] text-base text-black py-2 px-4 rounded-full focus:outline-none focus:shadow-outline w-full minlg:w-[250px] mt-6" type="button">
             Load More

--- a/components/modules/NFTDetail/NFTDetail.tsx
+++ b/components/modules/NFTDetail/NFTDetail.tsx
@@ -228,8 +228,8 @@ export const NFTDetail = (props: NFTDetailProps) => {
       </div>
       {
         (
-          (currentAddress === props.nft?.wallet?.address) ||
-          (currentAddress !== props.nft?.wallet?.address && !isNullOrEmpty(props.nft?.memo)))
+          (currentAddress === props.nft?.wallet?.address && !isNullOrEmpty(currentAddress)) ||
+          (currentAddress !== props.nft?.wallet?.address && !isNullOrEmpty(props.nft?.wallet?.address) && !isNullOrEmpty(props.nft?.memo)))
           &&
           <div className="flex minxl:basis-1/2">
             <NFTDetailContextProvider nft={props.nft} >


### PR DESCRIPTION
# Describe your changes
The load more / activity page doesn't check for empty arrays. It should show "no activity" instead
<img width="662" alt="Screenshot 2023-01-26 at 9 11 03 AM" src="https://user-images.githubusercontent.com/7184919/214860152-a5fb4c6d-5975-4596-aee2-2c41070099db.png">

In addition the nft memo is showing when both owner and current address are undefined, which is not intended behavior.
<img width="676" alt="Screenshot 2023-01-26 at 9 14 17 AM" src="https://user-images.githubusercontent.com/7184919/214860313-26578cb6-32e0-4811-8abe-ebbf36709d5b.png">

<img width="632" alt="Screenshot 2023-01-26 at 9 10 59 AM" src="https://user-images.githubusercontent.com/7184919/214860295-91624d97-dca9-4540-8718-5af36a0ab3e3.png">


- 

# Associated JIRA task link


- LINK-TO-JIRA-TASK


# Checklist before requesting a review


- [ ] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

