### PR TITLE
lower 10 min nft.com listing padding to 1 min

### DIFF
--- a/utils/nativeMarketplaceHelpers.ts
+++ b/utils/nativeMarketplaceHelpers.ts
@@ -513,7 +513,8 @@ export async function createNativeParametersForNFTListing(
 ): Promise<UnsignedOrder> {
   const salt = moment.utc().unix();
   const now = Date.now();
-  const start = noExpirationNFTCOM ? 0 : Math.floor((now / 1000) - (60 * 10));
+  // 1 minutes before for padding
+  const start = noExpirationNFTCOM ? 0 : Math.floor((now / 1000) - (60 * 1));
   const end = noExpirationNFTCOM ? 0 : Math.floor((now + duration * 1000) / 1000);
   
   const unsignedOrder: UnsignedOrder = await getUnsignedOrder(


### PR DESCRIPTION
# Describe your changes

- lower listing padding to 1 min, so activities page is more correct

# Associated JIRA task link


- [LINK-TO-JIRA-TASK](https://nftcom.atlassian.net/browse/NFT-1368?atlOrigin=eyJpIjoiZDFjZWRhOGQxOTIxNDk2YThjMDllNjNjZGFhNjM2YTIiLCJwIjoiaiJ9)


# Checklist before requesting a review


- [ ] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

