### PR TITLE
Adjust validation in useEffect hook

### DIFF
--- a/components/modules/Profile/ProfileContext.tsx
+++ b/components/modules/Profile/ProfileContext.tsx
@@ -274,7 +274,7 @@ export function ProfileContextProvider(
       });
 
       // Edit mode NFTS rendering for the first time
-      if (isNullOrEmpty(editModeNfts) && afterCursorEditMode === '') {
+      if (isNullOrEmpty(editModeNfts) && afterCursorEditMode === '' && allOwnerNfts.length > 0) {
         setPubliclyVisibleNfts([...allOwnerNftsWithHiddenValue.filter(nft => !nft.isHide)]);
         const paginatedNotPubliclyVisibleNftsLast = paginatedAllOwnerNfts?.filter(nft => publiclyVisibleNfts?.find(nft2 => nft2.id === nft.id) == null) ?? [];
         setPaginatedAllOwnerNfts([...allOwnerNftsWithHiddenValue]);


### PR DESCRIPTION
# Describe your changes

- Adjust validation in useEffect hook - In order to reproduce this bug it was necessary to use addresses minting a profile for the first time, which ensures it doesnt have no nfts related to it. The useEffect hook that handles pagination for editmode nfts was missing a validation to avoid running infinetly if the profile did not have any nfts when first rendering profile page for a recently minted profile

**Before fix using address with no profile minted**
[screen-capture (9).webm](https://user-images.githubusercontent.com/41962103/218920685-5d63feb6-8329-4778-abde-38e9f51a3227.webm)

**After the fix using address with no profile minted**
[screen-capture (10).webm](https://user-images.githubusercontent.com/41962103/218920999-13235e56-57a6-45ae-84b7-ed6f4871c3b0.webm)


# Associated JIRA task link


- https://nftcom.atlassian.net/browse/NFT-1532


# Checklist before requesting a review


- [ ] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work


## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)


- Link(s) to Prior Work: 

