### PR TITLE
fix: pull restrictive csp headers

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -1,9 +1,6 @@
 // TODO: Need to get inventory of domains to allow (frame-ancestors newer ver of x-frame-options)
 const ContentSecurityPolicy = `
   frame-ancestors 'none';
-  script-src 'self' https://www.googletagmanager.com https://connect.facebook.net nonce-pb+/pfhRedphzqIYzlBxMA== nonce-gGkqzVy6zqm4Aoyp9I4H5g== nonce-375Pd+0smY3JyJkGZJLKnA==;
-  style-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
-  font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
 `;
 
 const securityHeaders = [


### PR DESCRIPTION
# Describe your changes

- patch csp policy, only use `frame-ancestors 'none';` header to prevent restricting external scripts, fonts, styles, etc.


# Associated JIRA task link

- LINK-TO-JIRA-TASK

# Routes affected by changes
## example: '/app/list'


# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work
## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)

- Link(s) to Prior Work: 

