### PR TITLE
fix: only save collection view when associated collection selected

### DIFF
--- a/components/modules/Profile/MintedProfile.tsx
+++ b/components/modules/Profile/MintedProfile.tsx
@@ -126,7 +126,7 @@ export function MintedProfile(props: MintedProfileProps) {
     }
   };
   if (
-    associatedContract != null &&
+    associatedContract?.chainAddr?.length &&
     (Doppler.NEXT_PUBLIC_OFFCHAIN_ASSOCIATION_ENABLED ||
     (associatedAddresses?.find(addr => sameAddress(addr?.chainAddr, associatedCollectionWithDeployer?.deployer)) || sameAddress(profileData?.profile?.owner?.address, associatedCollectionWithDeployer?.deployer)))
   ) {

--- a/components/modules/Settings/AssociatedProfileSelect.tsx
+++ b/components/modules/Settings/AssociatedProfileSelect.tsx
@@ -19,8 +19,9 @@ const DynamicResultsDropDown = dynamic<React.ComponentProps<typeof ResultsDropDo
 type AssociatedProfileSelectProps = {
   profileId: string;
   associatedContract?: string;
+  onAssociatedContract: () => void;
 };
-export default function AssociatedProfileSelect({ profileId, associatedContract }: AssociatedProfileSelectProps) {
+export default function AssociatedProfileSelect({ profileId, associatedContract, onAssociatedContract }: AssociatedProfileSelectProps) {
   const { fetchTypesenseSearch } = useFetchTypesenseSearch();
   const { updateProfile } = useUpdateProfileMutation();
   const defaultChainId = useDefaultChainId();
@@ -137,6 +138,7 @@ export default function AssociatedProfileSelect({ profileId, associatedContract 
   const onButtonClickHandler = () => {
     if (selectedResult) {
       toast.success('Saved!');
+      onAssociatedContract();
       updateProfile({
         id: profileId,
         associatedContract: selectedResult.contractAddr,

--- a/components/modules/Settings/DisplayMode.tsx
+++ b/components/modules/Settings/DisplayMode.tsx
@@ -1,3 +1,4 @@
+import { ProfileViewType } from 'graphql/generated/types';
 import { useProfileQuery } from 'graphql/hooks/useProfileQuery';
 import { useUpdateProfileViewMutation } from 'graphql/hooks/useUpdateProfileViewMutation';
 import { Doppler, getEnvBool } from 'utils/env';
@@ -26,12 +27,22 @@ export default function DisplayMode({ selectedProfile }: DisplayModeProps) {
   }, [profileData?.profile?.profileView, selectedProfile]);
 
   const handleChange = event => {
-    toast.success('Saved!');
     setSelected(event.target.value);
-    updateProfileView({ profileViewType: event.target.value, url: selectedProfile }).catch(() => toast.error('Error'));
+    if (event.target.value !== ProfileViewType.Collection) {
+      toast.success('Saved!');
+      updateProfileView({ profileViewType: event.target.value, url: selectedProfile }).catch(() => toast.error('Error'));
+      gtag('event', 'Profile View Updated', {
+        profile: selectedProfile,
+        profileViewType: event.target.value
+      });
+    }
+  };
+
+  const handleAssociatedContract = () => {
+    updateProfileView({ profileViewType: selected as ProfileViewType, url: selectedProfile }).catch(() => toast.error('Error'));
     gtag('event', 'Profile View Updated', {
       profile: selectedProfile,
-      profileViewType: event.target.value
+      profileViewType: selected
     });
   };
 
@@ -61,7 +72,7 @@ export default function DisplayMode({ selectedProfile }: DisplayModeProps) {
       {
         selected === 'Collection' && (
           getEnvBool(Doppler.NEXT_PUBLIC_OFFCHAIN_ASSOCIATION_ENABLED)
-            ? <AssociatedProfileSelect {...{ profileId: profileData.profile.id, associatedContract: profileData.profile.associatedContract }} />
+            ? <AssociatedProfileSelect {...{ profileId: profileData.profile.id, associatedContract: profileData.profile.associatedContract, onAssociatedContract: handleAssociatedContract }} />
             : <ConnectedCollections {...{ selectedProfile }} />
         )
       }


### PR DESCRIPTION
# Describe your changes

- only save collection view when associated collection selected
- only show collection view when associated collection is not null or empty


# Associated JIRA task link

- [LINK-TO-JIRA-TASK](https://nftcom.atlassian.net/browse/NFT-1976)

# Routes affected by changes
## example: '/app/list'
/app/settings
/[profileUrl]

# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work
## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)

- Link(s) to Prior Work: 

