### PR TITLE
fix: patch like button z-index on discover search

### DIFF
--- a/components/modules/Search/ResultsDropDownDisplay.tsx
+++ b/components/modules/Search/ResultsDropDownDisplay.tsx
@@ -119,7 +119,7 @@ export const ResultsDropDownDisplay = ({ isHeader, searchResults, resultTitleOnC
   return (
     <div
       className={tw(
-        isHeader ? 'absolute left-0 max-w-[27rem]' : '',
+        isHeader ? 'absolute left-0 max-w-[27rem] z-[51]' : '',
         'flex flex-col w-full font-noi-grotesk',
         extraClasses)}>
       {searchResults.length > 0 && <>

--- a/pages/app/discover/nfts/index.tsx
+++ b/pages/app/discover/nfts/index.tsx
@@ -22,7 +22,7 @@ function usePrevious(value) {
   return ref.current;
 }
 
-export default function CollectionsPage() {
+export default function DiscoverNftsPage() {
   const [page, setPage] = useState(1);
   const { sideNavOpen, setSideNavOpen, setSearchModalOpen, nftsResultsFilterBy, setClearedFilters, setIsDiscoverCollections, isDiscoverCollections } = useSearchModal();
   const { fetchTypesenseSearch } = useFetchTypesenseSearch();
@@ -183,7 +183,7 @@ export default function CollectionsPage() {
   );
 }
 
-CollectionsPage.getLayout = function getLayout(page) {
+DiscoverNftsPage.getLayout = function getLayout(page) {
   return (
     <DefaultLayout showDNavigation={true}>
       {page}


### PR DESCRIPTION
# Describe your changes

- Fixes like button clipping over discover search results dropdown.  
### Before
<img width="900" alt="image" src="https://user-images.githubusercontent.com/19197856/233164563-5257f637-8051-4a52-bfa8-848ae3892003.png">

### After
<img width="900" alt="image" src="https://user-images.githubusercontent.com/19197856/233164286-bf6684db-e618-494f-bf56-31cbf1719de2.png">

# Associated JIRA task link

- [NFT-1982](https://nftcom.atlassian.net/browse/NFT-1982?atlOrigin=eyJpIjoiMGViYjE4ODA2NzRmNGJlNzhmZTYyODgyMGI4YjM0YWIiLCJwIjoiaiJ9)

# Routes affected by changes
## example: '/app/list'
- `/app/discover/*`

# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work
## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)

- Link(s) to Prior Work: 



[NFT-1982]: https://nftcom.atlassian.net/browse/NFT-1982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ