### PR TITLE
fix: patches collection banners & pages

### DIFF
--- a/components/elements/BlurImage.tsx
+++ b/components/elements/BlurImage.tsx
@@ -19,6 +19,7 @@ export default function BlurImage({
   height,
   fill,
   src,
+  sizes,
   localImage = false,
   ...props
 } : BlurImageProps) {
@@ -27,7 +28,7 @@ export default function BlurImage({
   const layoutProps = fill ?
     {
       fill,
-      sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+      sizes: sizes ?? '100vw',
     }
     : {
       width,
@@ -50,7 +51,7 @@ export default function BlurImage({
         'duration-500 ease-in-out',
         isLoading
           ? 'blur scale-110 animate-pulse'
-          : 'blur-0 scale-100'
+          : 'blur-none scale-100'
       )}
       onLoadingComplete={() => setIsLoading(false)}
       {...props}

--- a/components/elements/RoundedCornerMedia.tsx
+++ b/components/elements/RoundedCornerMedia.tsx
@@ -33,6 +33,7 @@ export enum RoundedCornerAmount {
 
 export interface RoundedCornerMediaProps {
   src: string;
+  sizes?: string;
   priority?: boolean;
   fallbackImage?: string;
   loader?: ImageLoader;
@@ -95,6 +96,7 @@ export const RoundedCornerMedia = React.memo(function RoundedCornerMedia({
   objectFit,
   onClick,
   priority,
+  sizes,
   src,
   variant,
   videoOverride
@@ -193,6 +195,7 @@ export const RoundedCornerMedia = React.memo(function RoundedCornerMedia({
           (imageUrl != 'null?width=600') && <DynamicRoundedCornerMediaImage
             priority={priority}
             src={imageUrl}
+            sizes={sizes}
             width={300}
             loader={defaultImgloader}
             onError={() => {

--- a/components/modules/Collection/Collection.tsx
+++ b/components/modules/Collection/Collection.tsx
@@ -95,7 +95,7 @@ export function Collection(props: CollectionProps) {
   // Data Fetching
   const { fetchTypesenseMultiSearch } = useFetchTypesenseSearch();
   const collectionSalesHistory = useGetContractSalesStatisticsQuery(collectionContract);
-  const collectionNFTInfo = useGetNFTDetailsQuery(collectionContract, collectionNfts[0]?.document?.tokenId);
+  const collectionNFTInfo = useGetNFTDetailsQuery(collectionContract, collectionNfts[0]?.document?.tokenId ?? '1'); // set fallback to 1st token in collection
   const { data: collectionData, mutate: mutateCollectionData } = useCollectionQuery(
     propsGuard.type === 'contract' && !slug ?
       {
@@ -250,15 +250,15 @@ export const CollectionBanner: React.FC = () => {
   const { collectionNFTInfo, collectionData } = useCollectionContext();
 
   // ! NOTE: Added fallback banner from collectionData, but image might be low res/quality.
-  const imageOverride = !collectionNFTInfo?.error
+  const imageOverride = useMemo(() => !collectionNFTInfo?.error
     ? (collectionNFTInfo?.data?.contract?.metadata?.banner_url?.replace('?w=500', '?w=3000') || collectionNFTInfo?.data?.contract?.metadata?.cached_banner_url)
-    : collectionData?.collection?.bannerUrl;
+    : collectionData?.collection?.bannerUrl, [collectionNFTInfo?.error, collectionNFTInfo?.data?.contract?.metadata?.banner_url, collectionNFTInfo?.data?.contract?.metadata?.cached_banner_url, collectionData?.collection?.bannerUrl]);
 
   return (
     <div className="mt-20">
       <BannerWrapper
         alt={`${collectionData?.collection?.name} Banner Image`}
-        loading={Boolean(collectionNFTInfo.loading)}
+        loading={Boolean(collectionNFTInfo?.loading)}
         imageOverride={imageOverride}
         isCollection
       />
@@ -298,7 +298,7 @@ export const CollectionHeader: React.FC<CollectionHeaderProps> = ({ children }) 
           <div className='flex'>
             {collectionPreferredOwnerData &&
               <div className='relative h-10 w-10 overflow-hidden'>
-                <BlurImage src={collectionPreferredOwnerData?.profile?.photoURL || 'https://cdn.nft.com/profile-image-default.svg'} alt='test' className='rounded-[10px] mr-2 object-cover' fill />
+                <BlurImage src={collectionPreferredOwnerData?.profile?.photoURL || 'https://cdn.nft.com/profile-image-default.svg'} alt='test' className='rounded-[10px] mr-2 object-cover' fill sizes='40px' />
               </div>
             }
             <div className={tw(
@@ -519,7 +519,7 @@ export const CollectionBody: React.FC = () => {
       label: 'Activity',
     }
   ];
-  
+
   return (
     <>
       <div className={cl(

--- a/components/modules/DiscoveryCards/CollectionCard.tsx
+++ b/components/modules/DiscoveryCards/CollectionCard.tsx
@@ -77,6 +77,7 @@ export function CollectionCard(props: CollectionCardProps) {
           variant={RoundedCornerVariant.None}
           width={600}
           height={600}
+          sizes="(max-width: 768px) 300px, 500px"
           containerClasses='w-[100%] object-cover h-[100%]'
           src={processedImageURLs[0]}
           extraClasses="hover:scale-105 transition"

--- a/components/modules/DiscoveryCards/CollectionLeaderBoardCard.tsx
+++ b/components/modules/DiscoveryCards/CollectionLeaderBoardCard.tsx
@@ -145,8 +145,9 @@ export function CollectionLeaderBoardCard(props: CollectionLeaderBoardCardProps)
           <div className="w-14 ml-2 rounded-[16px] overflow-hidden">
             <RoundedCornerMedia
               variant={RoundedCornerVariant.None}
-              width={600}
-              height={600}
+              width={80}
+              height={80}
+              sizes='80px'
               containerClasses='w-[100%] object-cover h-[100%]'
               src={props?.logoUrl}
               extraClasses="hover:scale-105 transition"
@@ -210,8 +211,9 @@ export function CollectionLeaderBoardCard(props: CollectionLeaderBoardCardProps)
             <div className="w-20  rounded-[16px] overflow-hidden">
               <RoundedCornerMedia
                 variant={RoundedCornerVariant.None}
-                width={600}
-                height={600}
+                width={80}
+                height={80}
+                sizes="80px"
                 containerClasses='w-[100%] object-cover h-[100%]'
                 src={props?.logoUrl}
                 extraClasses="hover:scale-105 transition"

--- a/components/modules/NFTCard/NFTCardImage.tsx
+++ b/components/modules/NFTCard/NFTCardImage.tsx
@@ -114,6 +114,7 @@ export function NFTCardImage(props: NFTCardImageProps) {
     )}>
       <div className='group-hover/ntfCard:scale-110 hover:scale-105 transition'>
         <RoundedCornerMedia
+          sizes="380px"
           variant={RoundedCornerVariant.None}
           width={600}
           height={600}

--- a/components/modules/Profile/BannerWrapper.tsx
+++ b/components/modules/Profile/BannerWrapper.tsx
@@ -3,7 +3,7 @@ import Loader from 'components/elements/Loader/Loader';
 import { Doppler, getEnvBool } from 'utils/env';
 import { tw } from 'utils/tw';
 
-import { nftComCdnLoader } from 'lib/image/loader';
+import { useMemo } from 'react';
 import { PropsWithChildren } from 'react';
 
 export interface BannerWrapperProps {
@@ -20,8 +20,8 @@ const defaultBanner = getEnvBool(Doppler.NEXT_PUBLIC_ANALYTICS_ENABLED) ?
   'https://cdn.nft.com/collectionBanner_default.png'
   : 'https://cdn.nft.com/profile-banner-default-logo-key.png';
 
-export function BannerWrapper({ alt = 'banner image', children, imageOverride, loading, onMouseEnter, onMouseLeave }: PropsWithChildren<BannerWrapperProps>) {
-  const imageUrl = imageOverride || defaultBanner;
+export function BannerWrapper({ alt = 'banner image', children, draft, imageOverride, loading, onMouseEnter, onMouseLeave }: PropsWithChildren<BannerWrapperProps>) {
+  const imageUrl = useMemo(() => imageOverride && !loading ? imageOverride : defaultBanner, [imageOverride, loading]);
 
   return (
     <div
@@ -37,8 +37,7 @@ export function BannerWrapper({ alt = 'banner image', children, imageOverride, l
       <BlurImage
         alt={alt}
         src={imageUrl}
-        width={3000}
-        loader={nftComCdnLoader}
+        localImage={draft}
         sizes="100vw"
         className="object-cover"
         fill

--- a/graphql/hooks/useGetNFTDetailsQuery.ts
+++ b/graphql/hooks/useGetNFTDetailsQuery.ts
@@ -22,12 +22,11 @@ export interface NFTDetailsData {
 export function useGetNFTDetailsQuery(contractAddress: string, tokenId: string): NFTDetailsData {
   const sdk = useGraphQLSDK();
   const { chain } = useNetwork();
-  const publicId = getEnv(Doppler.NEXT_PUBLIC_CHAIN_ID);
-  const isEthMainNet = chain?.id === 1 && publicId === '1';
-  const hasMissingArgs = isNullOrEmpty(contractAddress) || isNullOrEmpty(tokenId);
-  const shouldFetch = !hasMissingArgs && !isEthMainNet;
+  const chainId = chain?.id ? String(chain?.id) : getEnv(Doppler.NEXT_PUBLIC_CHAIN_ID);
+  const shouldFetch = !(isNullOrEmpty(contractAddress) || isNullOrEmpty(tokenId));
+
   const args = {
-    chainId: String(chain?.id || publicId),
+    chainId,
     contractAddress,
     tokenId
   };

--- a/lib/graphql-ssr/collection.ts
+++ b/lib/graphql-ssr/collection.ts
@@ -16,7 +16,7 @@ export const getCollectionPage = async (params: ParsedUrlQuery) => {
   const input = contract ? { input: { ...baseInput, contract } } : { input: { ...baseInput, slug } };
   const caseInsensitiveAddr = contract?.toString().toLowerCase();
 
-  if (!utils.isAddress(caseInsensitiveAddr) || !getEnvBool(Doppler.NEXT_PUBLIC_COLLECTION_PAGE_ENABLED)) {
+  if (!slug && (!utils.isAddress(caseInsensitiveAddr) || !getEnvBool(Doppler.NEXT_PUBLIC_COLLECTION_PAGE_ENABLED))) {
     return {
       props: {
         fallback: {
@@ -54,11 +54,14 @@ export const getCollectionPage = async (params: ParsedUrlQuery) => {
   }
   `;
 
-  const data: CollectionResponse = await request(
+  const data: Pick<CollectionResponse, 'collection'> = await request(
     getEnv(Doppler.NEXT_PUBLIC_GRAPHQL_URL),
     query,
     input
-  ).then(data => data.collection ?? {});
+  ).then(data => data.collection ?? {}).catch(err => {
+    console.error('getCollectionPage Server Req  Failed: ', err);
+    return {};
+  });
 
   return {
     props: {

--- a/pages/app/collection/[contractAddr].tsx
+++ b/pages/app/collection/[contractAddr].tsx
@@ -52,7 +52,7 @@ export default function UnofficialCollectionPage({ fallback }: InferGetServerSid
   return (
     <SWRConfig value={fallback}>
       <NextSeo
-        {...{ ...seoConfig }}
+        {...seoConfig }
       />
       <Collection contract={contractAddr as string} >
         <CollectionBanner />


### PR DESCRIPTION
# Describe your changes

- Patches collection pages.
  - Loading behavior should now no longer have the layout shift w/footer.
  - Banners should load in properly now.
  - Official collection urls should now render properly using SSR prefetching. 
  - Memoized various collection banner states to only trigger rerenders on state change.
  - Added `sizes` props to various components for better image scaling/loading. 
  - Fixes bug where collection banners are blank (black bg) if signed in.


# Associated JIRA task link

- [NFT-1999](https://nftcom.atlassian.net/browse/NFT-1999)
- [NFT-2000](https://nftcom.atlassian.net/browse/NFT-2000)

# Routes affected by changes
## example: '/app/list'
- `/app/collection/*`

# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work
## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)

- Link(s) to Prior Work: 



[NFT-1999]: https://nftcom.atlassian.net/browse/NFT-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NFT-2000]: https://nftcom.atlassian.net/browse/NFT-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ