### PR TITLE
fix: allow robots.txt to index official collection

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -18,6 +18,7 @@ module.exports = {
         disallow: ['/*'],
         allow: [
           '/$',
+          '/app/collection/official/*',
           '/app/discover',
           '/app/discover/*',
           '/articles',


### PR DESCRIPTION
# Describe your changes

- Hotfix patch adds official collections routes to robots.txt to enable indexing.


# Associated JIRA task link

- LINK-TO-JIRA-TASK

# Routes affected by changes
## example: '/app/list'


# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work
## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)

- Link(s) to Prior Work: 

