### PR TITLE
fix: add fallback for nft title.

### DIFF
--- a/components/modules/NFTDetail/NFTDetailPage.tsx
+++ b/components/modules/NFTDetail/NFTDetailPage.tsx
@@ -18,6 +18,7 @@ import { NFTDetailFeaturedBy } from './NFTDetailFeaturedBy';
 import { NFTDetailMoreFromCollection } from './NFTDetailMoreFromCollection';
 import { Properties } from './Properties';
 
+import { BigNumber } from 'ethers';
 import { useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 import { useAccount } from 'wagmi';
@@ -27,13 +28,13 @@ export interface NFTDetailPageProps {
   tokenId: string;
 }
 
-export function NFTDetailPage(props: NFTDetailPageProps) {
+export function NFTDetailPage({ collection, tokenId }: NFTDetailPageProps) {
   const { address: currentAddress } = useAccount();
   const defaultChainId = useDefaultChainId();
-
-  const { data: nft, mutate: mutateNft } = useNftQuery(props.collection, props.tokenId);
-  const { data: collection } = useSWR(
-    () => props.collection ? ['ContractMetadata', props.collection] : null,
+  const hexTokenId = BigNumber.from(tokenId).toHexString();
+  const { data: nft, mutate: mutateNft } = useNftQuery(collection, hexTokenId);
+  const { data: collectionData } = useSWR(
+    () => collection ? ['ContractMetadata', collection] : null,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async ([url, contract]) => {
       return await getContractMetadata(contract, defaultChainId);
@@ -89,7 +90,7 @@ export function NFTDetailPage(props: NFTDetailPageProps) {
           )}>
             {(defaultChainId === '1') &&
               <div className="w-full md:px-4 pt-4 pb-6">
-                <ExternalListings nft={nft} collectionName={collection?.contractMetadata?.name} />
+                <ExternalListings nft={nft} collectionName={collectionData?.contractMetadata?.name} />
                 <NFTAnalyticsContainer data={nft} />
               </div>
             }
@@ -127,7 +128,7 @@ export function NFTDetailPage(props: NFTDetailPageProps) {
         <div className='flex minxl:w-1/2 w-full minxl:flex-col'>
           <NFTDetail nft={nft} onRefreshSuccess={() => {
             mutateNft();
-          }} key={nft?.id} />
+          }} key={nft?.id} tokenId={tokenId}/>
           <div className="hidden minxl:block minxl:pt-5">
             <DetailTabsComponent />
           </div>
@@ -135,7 +136,7 @@ export function NFTDetailPage(props: NFTDetailPageProps) {
         {(showListings || (nft?.wallet?.address ?? nft?.owner) === currentAddress || (!isNullOrEmpty(nft?.owner) && !isNullOrEmpty(nft?.wallet?.address))) ?
           <div className='flex minxl:w-1/2 w-full items-end minxl:items-start minxl:flex-col minxl:p-4 minxl:pt-12'>
             <div className="lg:hidden flex minxl:flex-row w-full items-start">
-              <ExternalListings nft={nft} collectionName={collection?.contractMetadata?.name} />
+              <ExternalListings nft={nft} collectionName={collectionData?.contractMetadata?.name} />
             </div>
             <div className="w-full hidden minxl:flex minxl:items-end">
               <NFTAnalyticsContainer data={nft} />
@@ -155,7 +156,7 @@ export function NFTDetailPage(props: NFTDetailPageProps) {
       </div>
       <NFTDetailMoreFromCollection
         hideTokenId={nft?.tokenId}
-        collectionName={nft?.contract?.toLowerCase() === '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85'.toLowerCase() ? 'ENS: Ethereum Name Service' : collection?.contractMetadata?.name}
+        collectionName={nft?.contract?.toLowerCase() === '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85'.toLowerCase() ? 'ENS: Ethereum Name Service' : collectionData?.contractMetadata?.name}
         contract={nft?.contract}
       />
       <div className="w-full my-10 flex items-center -px-4 minxl:max-w-nftcom minlg:max-w-[650px]">

--- a/pages/app/nft/[collection]/[tokenId].tsx
+++ b/pages/app/nft/[collection]/[tokenId].tsx
@@ -7,7 +7,6 @@ import NotFoundPage from 'pages/404';
 import { isNullOrEmpty } from 'utils/format';
 import { isValidContractSimple } from 'utils/helpers';
 
-import { BigNumber } from 'ethers';
 import { getNftPage } from 'lib/graphql-ssr/nft';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import dynamic from 'next/dynamic';
@@ -63,7 +62,7 @@ export default function NftPage({ fallback }: InferGetServerSidePropsType<typeof
     <ClientOnly>
       <NFTDetailPage
         collection={collection as string}
-        tokenId={BigNumber.from(tokenId).toHexString()}
+        tokenId={tokenId as string}
       />
     </ClientOnly>
   </SWRConfig>;


### PR DESCRIPTION
# Describe your changes

- Adds NFT title fallback name if no name is present in the nft detail query. 
- Fallback pattern will generate an NFT title based on the collection name and token number. (ex: `BoredApeKennelClub #123`)


# Associated JIRA task link

- [NFT-2001](https://nftcom.atlassian.net/browse/NFT-2001)

# Routes affected by changes
## example: '/app/list'


# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work
## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)

- Link(s) to Prior Work: 



[NFT-2001]: https://nftcom.atlassian.net/browse/NFT-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ