### PR TITLE
Fix/NFT-2005-patch-nft-order

### DIFF
--- a/components/elements/nonAuthLikeModal.tsx
+++ b/components/elements/nonAuthLikeModal.tsx
@@ -52,7 +52,7 @@ export default function NonAuthLikeModal(){
           ? (
             <div className='text-[44px] flex items-center justify-between -mt-[3rem] mb-10'>
               <span className='text-[#FAC213]'>/</span>{sliceString(profileName, 14, false)}
-              <Image src={likeButton} className='w-[40px] ml-4' alt={`${likedType} Preview Image`} />p
+              <Image src={likeButton} className='w-[40px] ml-4' alt={`${likedType} Preview Image`} />
             </div>
           )
           : null}

--- a/components/modules/Profile/ProfileContext.tsx
+++ b/components/modules/Profile/ProfileContext.tsx
@@ -213,7 +213,7 @@ export function ProfileContextProvider(
   const [draftHeaderImg, setDraftHeaderImg] = useState({ preview: '', raw: null });
   const [draftDisplayType, setDraftDisplayType] = useState(null);
   const [selectedCollection, setSelectedCollection] = useState<string>(null);
-  const [draftLayoutType, setDraftLayoutType] = useState<ProfileLayoutType>(null);
+  const [draftLayoutType, setDraftLayoutType] = useState<ProfileLayoutType>(profileData?.profile?.layoutType ?? ProfileLayoutType.Default);
   const [draftDeployedContractsVisible, setDraftDeployedContractsVisible] = useState<boolean>(profileData?.profile?.deployedContractsVisible);
 
   useEffect(() => {


### PR DESCRIPTION
# Describe your changes

- Patches profile updates persisting. 
- NOTE: This only patches profile updates, but bug where saves clear profile page nfts still persists.
  - Changes will do save now, but may require page reload to see changes.  
- Save errors were being caused by `layoutType` being left null during `updateProfile` mutation request.
```json
{
    "errors": [
        {
            "statusCode": "INTERNAL_SERVER_ERROR",
            "errorKey": "UNKNOWN",
            "message": "Cannot return null for non-nullable field Mutation.updateProfile.",
            "path": [
                "updateProfile"
            ]
        }
    ],
    "data": null
}
```


# Associated JIRA task link

- [NFT-1981](https://nftcom.atlassian.net/browse/NFT-1981)
-[NFT-2005](https://nftcom.atlassian.net/browse/NFT-2005)

# Routes affected by changes
## example: '/app/list'
- `/[profileURI]`

# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work
## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)

- Link(s) to Prior Work: 



[NFT-1981]: https://nftcom.atlassian.net/browse/NFT-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NFT-2005]: https://nftcom.atlassian.net/browse/NFT-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ