### PR TITLE
fix: force default layout type for profiles.

### DIFF
--- a/components/modules/Profile/ProfileContext.tsx
+++ b/components/modules/Profile/ProfileContext.tsx
@@ -198,7 +198,7 @@ export function ProfileContextProvider(
   /**
    * Profile v2 instant update state
    */
-  const [currentLayoutType, setCurrentLayoutType] = useState<ProfileLayoutType>(profileData?.profile?.layoutType);
+  const [currentLayoutType, setCurrentLayoutType] = useState<ProfileLayoutType>(ProfileLayoutType.Default);
   const [currentNftsDescriptionsVisible, setCurrentNftsDescriptionsVisible] = useState<boolean>(profileData?.profile?.nftsDescriptionsVisible);
 
   /**
@@ -213,7 +213,7 @@ export function ProfileContextProvider(
   const [draftHeaderImg, setDraftHeaderImg] = useState({ preview: '', raw: null });
   const [draftDisplayType, setDraftDisplayType] = useState(null);
   const [selectedCollection, setSelectedCollection] = useState<string>(null);
-  const [draftLayoutType, setDraftLayoutType] = useState<ProfileLayoutType>(profileData?.profile?.layoutType ?? ProfileLayoutType.Default);
+  const [draftLayoutType, setDraftLayoutType] = useState<ProfileLayoutType>(ProfileLayoutType.Default);
   const [draftDeployedContractsVisible, setDraftDeployedContractsVisible] = useState<boolean>(profileData?.profile?.deployedContractsVisible);
 
   useEffect(() => {
@@ -231,7 +231,7 @@ export function ProfileContextProvider(
       setDraftDeployedContractsVisible(profileData?.profile?.deployedContractsVisible);
     }
     if(currentLayoutType == null){
-      setCurrentLayoutType(profileData?.profile?.layoutType);
+      setCurrentLayoutType(ProfileLayoutType.Default);
     }
     if(currentNftsDescriptionsVisible == null){
       setCurrentNftsDescriptionsVisible(profileData?.profile?.nftsDescriptionsVisible);
@@ -246,8 +246,7 @@ export function ProfileContextProvider(
     profileData?.profile?.deployedContractsVisible,
     profileData?.profile?.description,
     profileData?.profile?.gkIconVisible,
-    profileData?.profile?.nftsDescriptionsVisible,
-    profileData?.profile?.layoutType
+    profileData?.profile?.nftsDescriptionsVisible
   ]);
 
   // make sure this doesn't overwrite local changes, use server-provided value for initial state only.
@@ -417,7 +416,7 @@ export function ProfileContextProvider(
     setDraftNftsDescriptionsVisible(draftNftsDescriptionsVisible);
     setDraftDeployedContractsVisible(profileData?.profile?.deployedContractsVisible);
     setEditMode(false);
-    setDraftLayoutType(null);
+    setDraftLayoutType(ProfileLayoutType.Default);
     setPubliclyVisibleNfts(null);
     setEditModeNfts(null);
   }, [


### PR DESCRIPTION
# Describe your changes

- Forces profile layout type to always use default layout option. 
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/19197856/234379091-016bdb2a-9f76-48c1-acc2-ffd697baad20.png">



# Associated JIRA task link

- [NFT-2005](https://nftcom.atlassian.net/browse/NFT-2005)

# Routes affected by changes
## example: '/app/list'


# Checklist before requesting a review

- [x] I have performed a self-review of my code
    ## Describe your self-review process (if applicable):
       -
- [ ] I have added component tests for this work
- [ ] I have added e2e tests for this work
- [ ] I have properly gated the features with a doppler env variable:
  - [ ] updated sandbox doppler config
  - [ ] updated staging doppler config
  - [ ] updated production doppler config
  ## Include the added doppler env variables here (If applicable):
         -

# Prior Work
## If this is a follow-up PR to existing work, link the relevant PR(s) here (or N/A if not a follow-up)

- Link(s) to Prior Work: 



[NFT-2005]: https://nftcom.atlassian.net/browse/NFT-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ